### PR TITLE
Added ID-RAG paper to General section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Processing: A Survey**
 
 ### General
 
+**2025**
+
+- **ID-RAG: Identity Retrieval-Augmented Generation for Long-Horizon Persona Coherence in Generative Agents**
+[`Paper`](https://arxiv.org/abs/2509.25299) [`Code`](https://github.com/flybits/humanai-agents) `arXiv`
+
 **2024**
 
 - **Learning to Retrieve In-Context Examples for Large Language Models**  


### PR DESCRIPTION
Hello! I would like to add a new paper to the General section for 2025.

**Paper:** ID-RAG: Identity Retrieval-Augmented Generation for Long-Horizon Persona Coherence in Generative Agents
**Links:** [ArXiv](https://arxiv.org/abs/2509.25299) | [Code](https://github.com/flybits/humanai-agents)
**Venue:** Accepted to LLAIS 2025 (Workshop on LLM-Based Agents) at ECAI 2025.

This paper applies the concept of RAG towards maintaining self-perception and stable identity representation in Generative Agents.

Thank you!